### PR TITLE
Add: docker file for schedule viewer script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM pypy:2.7-7.1.0
 
-COPY requirements.txt ./
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+EXPOSE 8765
+
 ENTRYPOINT ["pypy", "./schedule_viewer.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM pypy:2.7-7.1.0
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["pypy", "./schedule_viewer.py"]

--- a/schedule_viewer.py
+++ b/schedule_viewer.py
@@ -553,6 +553,8 @@ https://github.com/google/transitfeed/wiki/ScheduleViewer
 
   print ("To view, point your browser at http://localhost:%d/" %
          (server.server_port))
+
+  sys.stdout.flush()
   server.serve_forever()
 
 


### PR DESCRIPTION
Added a dockerfile to enable running the schedule viewer inside a docker container.

Also, I added a line to flush the stdout. Sometimes when running the google visualizer, the last line wasn't getting printed but the server was already running. Flushing it forced it to print.